### PR TITLE
More build system improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,11 +41,20 @@ libnvidia_egl_wayland_la_built_sources =                             \
     wayland-eglstream/wayland-eglstream-controller-client-protocol.h
 
 nodist_libnvidia_egl_wayland_la_SOURCES = $(libnvidia_egl_wayland_la_built_sources)
-CLEANFILES = $(libnvidia_egl_wayland_la_built_sources)
 
 dist_pkgdata_DATA =                                    \
     wayland-eglstream/wayland-eglstream.xml            \
     wayland-eglstream/wayland-eglstream-controller.xml
+
+wayland_eglstream_pkgconfig_files = \
+    wayland-eglstream.pc            \
+    wayland-eglstream-protocols.pc
+
+noarch_pkgconfig_DATA = $(wayland_eglstream_pkgconfig_files)
+
+CLEANFILES =                                  \
+    $(libnvidia_egl_wayland_la_built_sources) \
+    $(wayland_eglstream_pkgconfig_files)
 
 $(libnvidia_egl_wayland_la_SOURCES): $(libnvidia_egl_wayland_la_built_sources)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,10 @@ libnvidia_egl_wayland_la_built_sources =                             \
 nodist_libnvidia_egl_wayland_la_SOURCES = $(libnvidia_egl_wayland_la_built_sources)
 CLEANFILES = $(libnvidia_egl_wayland_la_built_sources)
 
+dist_pkgdata_DATA =                                    \
+    wayland-eglstream/wayland-eglstream.xml            \
+    wayland-eglstream/wayland-eglstream-controller.xml
+
 $(libnvidia_egl_wayland_la_SOURCES): $(libnvidia_egl_wayland_la_built_sources)
 
 %-protocol.c : %.xml

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 AC_PREREQ([2.64])
 
-m4_define([wayland_external_major_version], [1])
-m4_define([wayland_external_minor_version], [0])
-m4_define([wayland_external_micro_version], [2])
-m4_define([wayland_external_version],
-          [wayland_external_major_version.wayland_external_minor_version.wayland_external_micro_version])
+m4_define([wayland_eglstream_major_version], [1])
+m4_define([wayland_eglstream_minor_version], [0])
+m4_define([wayland_eglstream_micro_version], [2])
+m4_define([wayland_eglstream_version],
+          [wayland_eglstream_major_version.wayland_eglstream_minor_version.wayland_eglstream_micro_version])
 
-AC_INIT([wayland_external],
-        [wayland_external_version],
+AC_INIT([wayland-eglstream],
+        [wayland_eglstream_version],
         [mvicomoya@nvidia.com])
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -15,10 +15,10 @@ AC_CONFIG_AUX_DIR([build])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 
-AC_SUBST([WAYLAND_EXTERNAL_MAJOR_VERSION], [wayland_external_major_version])
-AC_SUBST([WAYLAND_EXTERNAL_MINOR_VERSION], [wayland_external_minor_version])
-AC_SUBST([WAYLAND_EXTERNAL_MICRO_VERSION], [wayland_external_micro_version])
-AC_SUBST([WAYLAND_EXTERNAL_VERSION], [wayland_external_version])
+AC_SUBST([WAYLAND_EXTERNAL_MAJOR_VERSION], [wayland_eglstream_major_version])
+AC_SUBST([WAYLAND_EXTERNAL_MINOR_VERSION], [wayland_eglstream_minor_version])
+AC_SUBST([WAYLAND_EXTERNAL_MICRO_VERSION], [wayland_eglstream_micro_version])
+AC_SUBST([WAYLAND_EXTERNAL_VERSION], [wayland_eglstream_version])
 
 AC_SUBST([EGL_EXTERNAL_PLATFORM_MIN_VERSION], [${WAYLAND_EXTERNAL_MAJOR_VERSION}.${WAYLAND_EXTERNAL_MINOR_VERSION}])
 AC_SUBST([EGL_EXTERNAL_PLATFORM_MAX_VERSION], [$(($WAYLAND_EXTERNAL_MAJOR_VERSION + 1))])

--- a/configure.ac
+++ b/configure.ac
@@ -82,10 +82,13 @@ AX_CHECK_LINK_FLAG([-Xlinker --no-undefined],
 # Default CFLAGS
 CFLAGS="$CFLAGS -Wall -Wno-deprecated-declarations -Werror -include config.h"
 
-AC_CONFIG_FILES([Makefile])
-
 PKG_NOARCH_INSTALLDIR
 
+AC_CONFIG_FILES([
+    wayland-eglstream.pc
+    wayland-eglstream-protocols.pc
+    Makefile
+    ])
 AC_OUTPUT
 
 AC_MSG_RESULT([

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,9 @@ AX_CHECK_LINK_FLAG([-Xlinker --no-undefined],
 CFLAGS="$CFLAGS -Wall -Wno-deprecated-declarations -Werror -include config.h"
 
 AC_CONFIG_FILES([Makefile])
+
+PKG_NOARCH_INSTALLDIR
+
 AC_OUTPUT
 
 AC_MSG_RESULT([

--- a/wayland-eglstream-protocols.pc.in
+++ b/wayland-eglstream-protocols.pc.in
@@ -1,0 +1,7 @@
+prefix=@prefix@
+datarootdir=@datarootdir@
+pkgdatadir=@datadir@/@PACKAGE@
+
+Name: wayland-eglstream-protocols
+Description: Nvidia Wayland EGLStream XML protocol files
+Version: @WAYLAND_EXTERNAL_VERSION@

--- a/wayland-eglstream.pc.in
+++ b/wayland-eglstream.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: wayland-eglstream
+Description: Nvidia Wayland EGLStream compositor helper libraries
+Version: @WAYLAND_EXTERNAL_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lnvidia-egl-wayland
+Requires: eglexternalplatform >= @EGL_EXTERNAL_PLATFORM_MIN_VERSION@ eglexternalplatform < @EGL_EXTERNAL_PLATFORM_MAX_VERSION@


### PR DESCRIPTION
Since I finally managed to get Xwayland working with eglstreams, I figured it's about time to start cleaning things up and preparing to get these patches submitted at some point.
That being said, this patch series allows Xwayland and other projects to actually build against egl-wayland using pkg-config, so that we don't have to reinclude the same wayland protocol files for every project.

Wayland protocols are installed (by default) in `/usr/local/share/egl-wayland/wayland-eglstream*.xml`, similarly to the path scheme of the official wayland-protocols package. Everything else is installed in the usual directories.