### PR TITLE
meson: fix RuntimeError

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,7 @@ pkgconf.set('datarootdir', '${prefix}/@0@'.format(get_option('datadir')))
 pkgconf.set('PACKAGE',                           meson.project_name())
 pkgconf.set('WAYLAND_EXTERNAL_VERSION',          meson.project_version())
 pkgconf.set('EGL_EXTERNAL_PLATFORM_MIN_VERSION', '@0@.@1@'.format(wayland_eglstream_major_version, wayland_eglstream_minor_version))
-pkgconf.set('EGL_EXTERNAL_PLATFORM_MAX_VERSION', [wayland_eglstream_major_version.to_int() + 1])
+pkgconf.set('EGL_EXTERNAL_PLATFORM_MAX_VERSION', wayland_eglstream_major_version.to_int() + 1)
 
 configure_file(input : 'wayland-eglstream.pc.in',
                output : 'wayland-eglstream.pc',


### PR DESCRIPTION
The Meson build system
Version: 0.46.1

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 364, in run
    app.generate()
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 135, in generate
    self._generate(env)
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 186, in _generate
    intr.run()
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 3261, in run
    super().run()
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 215, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 239, in evaluate_codeblock
    raise e
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 231, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 244, in evaluate_statement
    return self.function_call(cur)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 504, in function_call
    return func(node, posargs, kwargs)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 99, in wrapped
    return f(s, node_or_state, args, kwargs)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 3070, in func_configure_file
    conf.held_object, format)
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonlib.py", line 627, in do_conf_file
    line, missing = do_replacement(regex, line, format, confdata)
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonlib.py", line 578, in do_replacement
    return re.sub(regex, variable_replace, line), missing_variables
  File "/usr/lib/python3.6/re.py", line 191, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonlib.py", line 573, in variable_replace
    raise RuntimeError('Tried to replace a variable with something other than a string or int.')
RuntimeError: Tried to replace a variable with something other than a string or int.