### PR TITLE
meson: replace 'private-code' on 'public-code'

### DIFF
--- a/wayland-eglstream/meson.build
+++ b/wayland-eglstream/meson.build
@@ -4,7 +4,7 @@ generated_protocols = [
 ]
 
 foreach proto : generated_protocols
-    foreach output_type: ['client-header', 'server-header', 'private-code']
+    foreach output_type: ['client-header', 'server-header', 'public-code']
         if output_type == 'client-header'
             output_file = '@0@-client-protocol.h'.format(proto)
         elif output_type == 'server-header'


### PR DESCRIPTION
The option "code" was deprecated in favour of "public-code" with a
warning message produced to guide people.

Fixes: https://github.com/NVIDIA/egl-wayland/issues/14