### PR TITLE
Fix sending garbage data in the wl_eglstream_display::caps event

### DIFF
--- a/src/wayland-eglstream-server.c
+++ b/src/wayland-eglstream-server.c
@@ -287,7 +287,7 @@ wl_eglstream_display_bind(WlEglPlatformData *data,
         return EGL_FALSE;
     }
 
-    wlStreamDpy = malloc(sizeof(*wlStreamDpy));
+    wlStreamDpy = calloc(1, sizeof(*wlStreamDpy));
     if (!wlStreamDpy) {
         return EGL_FALSE;
     }


### PR DESCRIPTION
The wl_eglstream_display::caps event currently ends up containing random garbage data, because the wl_eglstream_display_bind never initializes the supported_caps field value before it starts setting bits on it.

This changes it to use calloc to just zero the whole wl_eglstream_display struct before it starts filling anything in.