### PR TITLE
Fix interface type checks

### DIFF
--- a/include/wayland-eglutils.h
+++ b/include/wayland-eglutils.h
@@ -60,9 +60,9 @@ EGLBoolean wlEglFindExtension(const char *extension, const char *extensions);
 EGLBoolean wlEglPointerIsDereferencable(void *p);
 EGLBoolean wlEglCheckInterfaceType(struct wl_object *obj, const char *ifname);
 #ifndef WL_CHECK_INTERFACE_TYPE
-#define WL_CHECK_INTERFACE_TYPE(obj, ifname)                            \
-    (wlEglCheckInterfaceType((struct wl_object *)(obj), #ifname) ||     \
-     *(void **)(obj) == &ifname)
+#define WL_CHECK_INTERFACE_TYPE(obj, iftype, ifname)             \
+    (*(void **)(obj) == &iftype ||                               \
+    wlEglCheckInterfaceType((struct wl_object *)(obj), ifname))
 #endif
 #endif
 void wlEglSetErrorCallback(WlEglPlatformData *data,

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -42,7 +42,7 @@ EGLBoolean wlEglIsWaylandDisplay(void *nativeDpy)
         return EGL_FALSE;
     }
 
-    return WL_CHECK_INTERFACE_TYPE(nativeDpy, wl_display_interface);
+    return WL_CHECK_INTERFACE_TYPE(nativeDpy, wl_display_interface, "wl_display");
 #else
     (void)nativeDpy;
 

--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -69,7 +69,7 @@ EGLBoolean wlEglIsWaylandWindowValid(struct wl_egl_window *window)
             return EGL_FALSE;
         }
     }
-    return WL_CHECK_INTERFACE_TYPE(surface, wl_surface_interface);
+    return WL_CHECK_INTERFACE_TYPE(surface, wl_surface_interface, "wl_surface");
 #else
     /*
      * Note that dereferencing an invalid surface pointer could mean an old

--- a/src/wayland-eglutils.c
+++ b/src/wayland-eglutils.c
@@ -127,16 +127,12 @@ EGLBoolean wlEglPointerIsDereferencable(void *p)
 
 EGLBoolean wlEglCheckInterfaceType(struct wl_object *obj, const char *ifname)
 {
-
-    Dl_info info;
     /*
      * The first member of a wl_object is a pointer to its wl_interface,
      * so we can check if it corresponds to the given symbol name
      */
-    if (dladdr(*(void **)obj, &info) == 0) {
-        return EGL_FALSE;
-    }
-    return info.dli_sname && !strcmp(info.dli_sname, ifname);
+    struct wl_interface *interface = (struct wl_interface *)(*(uintptr_t *)obj);
+    return interface && !strcmp(interface->name, ifname);
 }
 #endif
 


### PR DESCRIPTION
This does 3 things:

1. Makes WL_CHECK_INTERFACE_TYPE check interface pointers first because
   it's faster.
2. Adds 3rd parameter to WL_CHECK_INTERFACE_TYPE (string with interface
   name). Real interface names do not contain "_interface" postfix
in their names.
3. Removes dladdr() call from wlEglCheckInterfaceType and checks interface names directly.
   dladdr() returns DL_info, which in turn includes name of shared object that owns
   passed adress. And it's not interface name, but process or library path,
   e.g. "/usr/bin/alacritty" or "/usr/lib/libegl-renderer.so.1".

Fixes at least #34