### PR TITLE
Improve wlEglMemoryIsReadable behavior

### DIFF
--- a/src/wayland-eglutils.c
+++ b/src/wayland-eglutils.c
@@ -68,7 +68,7 @@ static int try_pipe_write(int fd, const void *p, size_t len)
     if (result == -1 && errno == EAGAIN) {
         result = 0;
     }
-    assert(result != -1 || errno == EFAULT);
+    assert(result != -1 || errno == EFAULT || errno == EINVAL);
     return result;
 }
 

--- a/src/wayland-eglutils.c
+++ b/src/wayland-eglutils.c
@@ -71,7 +71,12 @@ EGLBoolean wlEglMemoryIsReadable(const void *p, size_t len)
 
     /* write will fail with EFAULT if the provided buffer is outside
      * our accessible address space. */
-    result = write(fds[1], p, len);
+    do {
+        result = write(fds[1], p, len);
+    } while (result == -1 && errno == EINTR);
+    if (result == -1 && errno == EAGAIN) {
+        result = 0;
+    }
     assert(result != -1 || errno == EFAULT);
 
 done:


### PR DESCRIPTION
The implementation of the recently added wlEglMemoryIsReadable function will not always check to see whether or not the entire range is readable thanks to some optimizations by the write function.

These patches make its check much more robust (although still not perfect) and handle edge cases such as EINTR, EAGAIN and EINVAL that the original implementation does not while adding only a very tiny (constant) amount of extra work.

With these changes it should almost always provide the correct answer, even on the *BSDs and without an assertion failure either.