### PR TITLE
generate wayland-drm-client-protocol.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,8 @@ libnvidia_egl_wayland_la_built_private_protocols =            \
 
 libnvidia_egl_wayland_la_built_client_headers =               \
     wayland-eglstream/wayland-eglstream-client-protocol.h     \
-    wayland-eglstream/wayland-eglstream-controller-client-protocol.h
+    wayland-eglstream/wayland-eglstream-controller-client-protocol.h \
+    wayland-drm/wayland-drm-client-protocol.h
 
 libnvidia_egl_wayland_la_built_server_headers =               \
     wayland-eglstream/wayland-eglstream-server-protocol.h     \

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,6 +47,7 @@ src = [
     wayland_eglstream_controller_protocol_c,
     wayland_eglstream_controller_client_protocol_h,
     wayland_drm_protocol_c,
+    wayland_drm_client_protocol_h,
     wayland_drm_server_protocol_h,
 ]
 

--- a/wayland-drm/meson.build
+++ b/wayland-drm/meson.build
@@ -1,5 +1,7 @@
-foreach output_type: ['server-header', 'public-code']
-    if output_type == 'server-header'
+foreach output_type: ['client-header', 'server-header', 'public-code']
+    if output_type == 'client-header'
+        output_file = 'wayland-drm-client-protocol.h'
+    elif output_type == 'server-header'
         output_file = 'wayland-drm-server-protocol.h'
     else
         output_file = 'wayland-drm-protocol.c'


### PR DESCRIPTION
Since d4937adc5cd04ac7df98fc5616e40319fb52fdee, `wayland-drm-client-protocol.h` is required. I just assume that it's the right way to generate it, but please amend if it should be done in some other way.