### PR TITLE
Defer resizes until next SwapBuffers (work around #52)

### DIFF
--- a/include/wayland-eglsurface.h
+++ b/include/wayland-eglsurface.h
@@ -128,10 +128,19 @@ typedef struct WlEglSurfaceRec {
      * before dispatching frame sync events in wlEglWaitFrameSync().
      */
     pthread_mutex_t mutexLock;
+
+    /* We want to delay the resizing of the window surface until the next
+     * eglSwapBuffers(), so just set a resize flag.
+     */
+    EGLBoolean isResized;
 } WlEglSurface;
 
 WL_EXPORT
 EGLBoolean wlEglInitializeSurfaceExport(WlEglSurface *surface);
+
+void wlEglResizeSurfaceIfRequired(WlEglDisplay *display,
+                                  WlEglPlatformData *pData,
+                                  WlEglSurface *surface);
 
 EGLSurface wlEglCreatePlatformWindowSurfaceHook(EGLDisplay dpy,
                                                 EGLConfig config,

--- a/src/wayland-eglswap.c
+++ b/src/wayland-eglswap.c
@@ -64,6 +64,8 @@ EGLBoolean wlEglSwapBuffersWithDamageHook(EGLDisplay eglDisplay, EGLSurface eglS
 
     surface = eglSurface;
 
+    wlEglResizeSurfaceIfRequired(display, data, surface);
+
     if (surface->pendingSwapIntervalUpdate == EGL_TRUE) {
         /* Send request from client to override swapinterval value based on
          * server's swapinterval for overlay compositing


### PR DESCRIPTION
As explained in #52 and https://github.com/libsdl-org/SDL/pull/4821, several games are broken under nVidia/Wayland due to calling wl_egl_window_resize() from a different thread.

This change works around this by deferring the resize until eglSwapBuffers(), which fixes the aforementioned games.

I'm not sure if this is the right solution to this problem — and the implementation could use a lot of cleanup, even so, but it seems to be a marked improvement for me.