### PR TITLE
[HACK] For Vulkan surfaces, assume opaque alpha composition.

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -1021,8 +1021,14 @@ acquire_surface_image(WlEglDisplay *display, WlEglSurface *surface)
         /*
          * Before sending the format, check if we are ignoring alpha due to a
          * surface attribute.
+	 *
+	 * HACK: Also ignore alpha if this is a Vulkan surface.
+	 * Currently the best way to detect a Vulkan surface is 'isSurfaceProducer',
+	 * and the Vulkan driver only exposes OPAQUE_BIT for VK_KHR_surface.
+	 * If the driver exposes more bits, this check should be updated with it!
+	 * -flibit
          */
-        if (surface->presentOpaque) {
+        if (surface->presentOpaque || !surface->isSurfaceProducer) {
             /*
              * We are ignoring alpha, so we need to find a DRM_FORMAT_* that is equivalent to
              * the current format, but ignores the alpha. i.e. RGBA -> RGBX


### PR DESCRIPTION
For more information, see the NVIDIA Developer Forums:

https://forums.developer.nvidia.com/t/wayland-vulkan-ignores-vkcompositealphaflagskhr/202227

This resolves the issue described in the above thread, but a potentially better fix would be for the driver to communicate this to egl-wayland explicitly.