### PR TITLE
Destroy all created wayland object in terminateDisplay

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -628,6 +628,10 @@ static EGLBoolean terminateDisplay(WlEglDisplay *display, EGLBoolean globalTeard
             wl_eglstream_display_destroy(display->wlStreamDpy);
             display->wlStreamDpy = NULL;
         }
+        if (display->wlStreamCtl) {
+            wl_eglstream_controller_destroy(display->wlStreamCtl);
+            display->wlStreamCtl = NULL;
+        }
         if (display->wpPresentation) {
             wp_presentation_destroy(display->wpPresentation);
             display->wpPresentation = NULL;


### PR DESCRIPTION
These object are created but never destroyed. When the library is unload this leaves dangling pointers in libwayland-client leading to things like:
https://bugzilla.mozilla.org/show_bug.cgi?id=1759315