### PR TITLE
Fix wrong destruction order for event queue

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -704,11 +704,11 @@ static void getServerProtocolsInfo(struct wl_display *nativeDpy,
         }
     }
 
+    if (wlRegistry) {
+        wl_registry_destroy(wlRegistry);
+    }
     if (queue) {
         wl_event_queue_destroy(queue);
-    }
-    if (wlRegistry) {
-       wl_registry_destroy(wlRegistry);
     }
 }
 


### PR DESCRIPTION
libwayland 1.22 added a [warning](https://gitlab.freedesktop.org/wayland/wayland/-/blob/1.22.0/src/wayland-client.c?ref_type=tags#L308) that could currently be triggered by running `eglgears_wayland` under NVIDIA wayland:
```
warning: queue 0x5560c4ce1b30 destroyed while proxies still attached:
  wl_registry@3 still attached
```
Firefox currently [crashes](https://bugzilla.mozilla.org/show_bug.cgi?id=1826583) upon such warnings. Mesa has fixed a similar bug in https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/21646