### PR TITLE
Implement Explicit Sync

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,12 @@ libnvidia_egl_wayland_la_dmabuf_built_client_headers =        \
 libnvidia_egl_wayland_la_dmabuf_built_private_protocols =     \
     linux-dmabuf-unstable-v1-protocol.c
 
+libnvidia_egl_wayland_la_drm_syncobj_built_client_headers =       \
+    linux-drm-syncobj-v1-client-protocol.h
+
+libnvidia_egl_wayland_la_drm_syncobj_built_private_protocols =    \
+    linux-drm-syncobj-v1-protocol.c
+
 libnvidia_egl_wayland_la_presentation_time_built_client_headers = \
     presentation-time-client-protocol.h
 
@@ -93,6 +99,8 @@ libnvidia_egl_wayland_la_built_sources =                               \
     $(libnvidia_egl_wayland_la_built_server_headers)                   \
     $(libnvidia_egl_wayland_la_dmabuf_built_client_headers)            \
     $(libnvidia_egl_wayland_la_dmabuf_built_private_protocols)         \
+    $(libnvidia_egl_wayland_la_drm_syncobj_built_client_headers)       \
+    $(libnvidia_egl_wayland_la_drm_syncobj_built_private_protocols)    \
     $(libnvidia_egl_wayland_la_presentation_time_built_client_headers) \
     $(libnvidia_egl_wayland_la_presentation_time_private_protocols)
 
@@ -127,6 +135,12 @@ $(libnvidia_egl_wayland_la_dmabuf_built_private_protocols):%-protocol.c : $(WAYL
 	$(AM_V_GEN)$(WAYLAND_SCANNER) $(WAYLAND_PRIVATE_CODEGEN) < $< > $@
 
 $(libnvidia_egl_wayland_la_dmabuf_built_client_headers):%-client-protocol.h : $(WAYLAND_PROTOCOLS_DATADIR)/unstable/linux-dmabuf/%.xml
+	$(AM_V_GEN)$(WAYLAND_SCANNER) client-header < $< > $@
+
+$(libnvidia_egl_wayland_la_drm_syncobj_built_private_protocols):%-protocol.c : $(WAYLAND_PROTOCOLS_DATADIR)/staging/linux-drm-syncobj/%.xml
+	$(AM_V_GEN)$(WAYLAND_SCANNER) $(WAYLAND_PRIVATE_CODEGEN) < $< > $@
+
+$(libnvidia_egl_wayland_la_drm_syncobj_built_client_headers):%-client-protocol.h : $(WAYLAND_PROTOCOLS_DATADIR)/staging/linux-drm-syncobj/%.xml
 	$(AM_V_GEN)$(WAYLAND_SCANNER) client-header < $< > $@
 
 $(libnvidia_egl_wayland_la_presentation_time_private_protocols):%-protocol.c : $(WAYLAND_PROTOCOLS_DATADIR)/stable/presentation-time/%.xml

--- a/include/wayland-egldisplay.h
+++ b/include/wayland-egldisplay.h
@@ -121,6 +121,9 @@ typedef struct WlEglDmaBufFeedbackRec {
 typedef struct WlEglDisplayRec {
     WlEglDeviceDpy *devDpy;
 
+    /* Supports EGL_ANDROID_native_fence_sync */
+    int supports_native_fence_sync;
+
     EGLBoolean         ownNativeDpy;
     struct wl_display *nativeDpy;
 
@@ -128,6 +131,7 @@ typedef struct WlEglDisplayRec {
     struct wl_eglstream_display    *wlStreamDpy;
     struct wl_eglstream_controller *wlStreamCtl;
     struct zwp_linux_dmabuf_v1     *wlDmaBuf;
+    struct wp_linux_drm_syncobj_manager_v1 *wlDrmSyncobj;
     unsigned int                    wlStreamCtlVer;
     struct wp_presentation         *wpPresentation;
     struct wl_event_queue          *wlEventQueue;
@@ -138,6 +142,9 @@ typedef struct WlEglDisplayRec {
     } caps;
 
     WlEglPlatformData *data;
+
+    /* DRM device in use */
+    int drmFd;
 
     EGLBoolean useInitRefCount;
     EGLDeviceEXT requestedDevice;

--- a/include/wayland-eglhandle.h
+++ b/include/wayland-eglhandle.h
@@ -108,7 +108,9 @@ typedef struct WlEglPlatformDataRec {
         PFNEGLCLIENTWAITSYNCKHRPROC                 clientWaitSync;
         PFNEGLSIGNALSYNCKHRPROC                     signalSync;
         PFNEGLDESTROYSYNCKHRPROC                    destroySync;
+        PFNEGLCREATESYNCKHRPROC                     createSync;
         PFNEGLSTREAMFLUSHNVPROC                     streamFlush;
+        PFNEGLDUPNATIVEFENCEFDANDROIDPROC           dupNativeFenceFD;
 
         /* Used for dma-buf surfaces */
         PFNEGLSTREAMIMAGECONSUMERCONNECTNVPROC      streamImageConsumerConnect;

--- a/include/wayland-eglsurface-internal.h
+++ b/include/wayland-eglsurface-internal.h
@@ -51,6 +51,14 @@ typedef struct WlEglStreamImageRec {
     struct wl_buffer       *buffer;
     EGLBoolean              attached;
     struct wl_list          acquiredLink;
+
+    struct wp_linux_drm_syncobj_timeline_v1 *wlReleaseTimeline;
+    uint32_t                drmSyncobjHandle;
+    int                     releasePending;
+    /* Latest release point the compositor will signal with explicit sync */
+    uint64_t                releasePoint;
+    /* Cached acquire EGLSync from acquireImage */
+    EGLSyncKHR              acquireSync;
 } WlEglStreamImage;
 
 typedef struct WlEglSurfaceCtxRec {
@@ -151,6 +159,13 @@ struct WlEglSurfaceRec {
     EGLBoolean isResized;
 
     WlEglDmaBufFeedback feedback;
+
+    /* per-surface Explicit Sync objects */
+    struct wp_linux_drm_syncobj_surface_v1 *wlSyncobjSurf;
+    struct wp_linux_drm_syncobj_timeline_v1 *wlAcquireTimeline;
+    uint32_t drmSyncobjHandle;
+    /* Last acquire point used. This starts at 1, zero means invalid.  */
+    uint64_t syncPoint;
 };
 
 void wlEglReallocSurface(WlEglDisplay *display,
@@ -184,6 +199,9 @@ EGLBoolean wlEglQueryNativeResourceHook(EGLDisplay dpy,
                                         void *nativeResource,
                                         EGLint attribute,
                                         int *value);
+
+EGLBoolean
+wlEglSurfaceCheckReleasePoints(WlEglDisplay *display, WlEglSurface *surface);
 
 EGLBoolean wlEglSendDamageEvent(WlEglSurface *surface,
                                 struct wl_event_queue *queue);

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ libdrm = dependency('libdrm')
 wl_protos_dir = wl_protos.get_pkgconfig_variable('pkgdatadir')
 wl_dmabuf_xml = join_paths(wl_protos_dir, 'unstable', 'linux-dmabuf', 'linux-dmabuf-unstable-v1.xml')
 wp_presentation_time_xml = join_paths(wl_protos_dir, 'stable', 'presentation-time', 'presentation-time.xml')
+wl_drm_syncobj_xml = join_paths(wl_protos_dir, 'staging', 'linux-drm-syncobj', 'linux-drm-syncobj-v1.xml')
 
 client_header = generator(prog_scanner,
     output : '@BASENAME@-client-protocol.h',
@@ -64,6 +65,9 @@ src += code.process(wl_dmabuf_xml)
 
 src += client_header.process(wp_presentation_time_xml)
 src += code.process(wp_presentation_time_xml)
+
+src += client_header.process(wl_drm_syncobj_xml)
+src += code.process(wl_drm_syncobj_xml)
 
 egl_wayland = library('nvidia-egl-wayland',
     src,

--- a/src/wayland-eglhandle.c
+++ b/src/wayland-eglhandle.c
@@ -111,6 +111,8 @@ wlEglCreatePlatformData(int apiMajor, int apiMinor, const EGLExtDriver *driver)
     GET_PROC(clientWaitSync,              eglClientWaitSyncKHR);
     GET_PROC(signalSync,                  eglSignalSyncKHR);
     GET_PROC(destroySync,                 eglDestroySyncKHR);
+    GET_PROC(createSync,                  eglCreateSyncKHR);
+    GET_PROC(dupNativeFenceFD,            eglDupNativeFenceFDANDROID);
 
     /* Stream flush */
     GET_PROC(streamFlush,                 eglStreamFlushNV);

--- a/src/wayland-eglswap.c
+++ b/src/wayland-eglswap.c
@@ -148,6 +148,7 @@ EGLBoolean wlEglSwapBuffersWithDamageHook(EGLDisplay eglDisplay, EGLSurface eglS
         } else {
             wlEglCreateFrameSync(surface);
             res = wlEglSendDamageEvent(surface, surface->wlEventQueue);
+            wlEglSurfaceCheckReleasePoints(display, surface);
         }
     }
 


### PR DESCRIPTION
This implements the explicit sync linux-drm-syncobj-v1 protocol for EGL.

This pull request exists to publicize our EGL implementation of explicit sync that we have been using to test the Mutter and Xwayland implementations. Erik and I have done a good amount of testing with this so it's in a fairly polished state and isn't just a first prototype.

Currently the code as proposed here will not build or run on existing drivers. To build it would need an updated wayland-protocols that contains linux-drm-syncobj, and to run it would require a newer (next upcoming release) NVIDIA driver that has the necessary prerequisites. Whenever this lands the minimum required NVIDIA driver version will also be bumped.

This change finally does away with the background threads which have given us issues in the past. Both the damage and the buffer release threads are disabled when explicit sync is supported.

-----

Most of this change involves wayland-protocol handling boilerplate. The protocol works by allowing the creation of timelines (i.e. DRM syncobjs) and per-surface states. We can then specify acquire and release points during our surface state configuration which will tell the compositor when it can access the buffer or notify us when it is finished accessing the buffer.

Sync point signaling takes place during acquire_surface_image. We choose our two release point values and send them to the compositor.  In the acquire case, the EGLSync will be created first and will be populated with a fence representing the GPU work. We can extract its syncfd and import it at the acquire point. We choose the release point during image acquisition, but don't actually create an EGLSync for it until later when the compositor has added a fence to the release point. We check if this has taken place after every surface commit.

Separate timelines are used for the acquire and release points. Each stream image will have its own timeline, otherwise our signaling of acquire points would implicitly signal the still-pending release points.