### PR TITLE
Fix the ABI version check.

### DIFF
--- a/src/wayland-external-exports.c
+++ b/src/wayland-external-exports.c
@@ -96,7 +96,8 @@ EGLBoolean loadEGLExternalPlatform(int major, int minor,
                                    EGLExtPlatform *platform)
 {
     if (!platform ||
-        !EGL_EXTERNAL_PLATFORM_VERSION_CHECK(major, minor)) {
+        !EGL_EXTERNAL_PLATFORM_VERSION_CMP(major, minor,
+            WAYLAND_EXTERNAL_VERSION_MAJOR, WAYLAND_EXTERNAL_VERSION_MINOR)) {
         return EGL_FALSE;
     }
 


### PR DESCRIPTION
This fixes the ABI version check in loadEGLExternalPlatform. It currently uses `EGL_EXTERNAL_PLATFORM_VERSION_CHECK`, which is correct for what `EGL_EXTERNAL_PLATFORM_HAS` does, but it's backwards from what we need to check the driver version.