### PR TITLE
egl-wayland: Validate and use the passed value of EGL_EXT_present_opaque

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -2351,7 +2351,9 @@ static EGLBoolean validateSurfaceAttrib(EGLAttrib attrib, EGLAttrib value)
         return EGL_FALSE;
 
     case EGL_PRESENT_OPAQUE_EXT:
-        return EGL_TRUE;
+        return (value == EGL_TRUE ||
+                value == EGL_FALSE) ? EGL_TRUE :
+                                      EGL_FALSE;
 
     /* If attribute is supported/unsupported for both EGL_WINDOW_BIT and
      * EGL_STREAM_BIT_KHR, then that will be handled inside the actual
@@ -2397,7 +2399,7 @@ static EGLint assignWlEglSurfaceAttribs(WlEglSurface *surface,
     if (attribs) {
         for (i = 0; attribs[i] != EGL_NONE; i += 2) {
             if (attribs[i] == EGL_PRESENT_OPAQUE_EXT) {
-                surface->presentOpaque = EGL_TRUE;
+                surface->presentOpaque = attribs[i + 1];
                 continue;
             }
             if ((attribs[i] != EGL_RENDER_BUFFER) &&


### PR DESCRIPTION
It was assumed that the presence of the EGL_PRESENT_OPAQUE_EXT enum in the surface attribute list meant that the alpha channel should be ignored as if it was always followed by a value of EGL_TRUE, however, according to the spec, valid usage allows for a value of EGL_FALSE as well, which should result in the alpha channel being used for blending.

Validate and use the value instead of assuming that the presence of the extension enum value implies that it is enabled.