### PR TITLE
wayland-eglsurface: Change type of timout from EGLint -> EGLTime

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -1588,7 +1588,7 @@ EGLint wlEglHandleImageStreamEvents(WlEglSurface *surface)
     EGLAttrib             aux;
     EGLenum               event;
     EGLint                err = EGL_SUCCESS;
-    EGLint                timeout = surface->wlSyncobjSurf ? EGL_FOREVER : 0;
+    EGLTime               timeout = surface->wlSyncobjSurf ? EGL_FOREVER : 0;
 
     if (surface->ctx.wlStreamResource) {
         /* Not a local stream */


### PR DESCRIPTION
This seems to be the appropriate type representation for timeout, moreover it also fixes an error with newer compilers where it complains about type mismatch between EGLint and EGL_FOREVER because EGL_FOREVER is defined as 0xFFFFFFFFFFFFFFFFull which is unsinged long long.

Fixes
| ../git/src/wayland-eglsurface.c:1591:62: error: implicit conversion from 'unsigned long long' to 'EGLint' (aka 'int') changes value from 18446744073709551615 to -1 [-Werror,]
|  1591 |     EGLint                timeout = surface->wlSyncobjSurf ? EGL_FOREVER : 0;
|       |                           ~~~~~~~                            ^~~~~~~~~~~
| /mnt/b/yoe/master/build/tmp/work/armv8a-yoe-linux/egl-wayland/1.1.13+git/recipe-sysroot/usr/include/EGL/egl.h:293:43: note: expanded from macro 'EGL_FOREVER'
|   293 | #define EGL_FOREVER                       0xFFFFFFFFFFFFFFFFull
|       |                                           ^~~~~~~~~~~~~~~~~~~~~
| 1 error generated.