### PR TITLE
egl-wayland: Fix memory leak in wlEglCreateSurfaceExport

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -2188,12 +2188,14 @@ WlEglSurface *wlEglCreateSurfaceExport(EGLDisplay dpy,
     if (!wlEglInitializeMutex(&surface->mutexFrameSync)) {
         pthread_mutex_unlock(&display->mutex);
         wlEglReleaseDisplay(display);
+        free(surface);
         return EGL_FALSE;
     }
 
     if (pthread_cond_init(&surface->condFrameSync, NULL)) {
         pthread_mutex_unlock(&display->mutex);
         wlEglReleaseDisplay(display);
+        free(surface);
         return EGL_FALSE;
     }
 


### PR DESCRIPTION
The "surface" variable is not freed in these 2 cases.

Fixes: 63e82b06fbc0 ("wayland-egl: avoid unnecessary commit")

---

Replacing that code branch with a `goto fail` might work as well. The maintainers will know better :) 