### PR TITLE
wayland-egl: Fix race condition in damage_thread

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -339,6 +339,8 @@ damage_thread(void *args)
         // If not done, keep handling frames
         if (ok) {
 
+            pthread_mutex_lock(&surface->mutexFrameSync);
+
             // If there's an unprocessed frame ready, send damage event
             if (surface->ctx.framesFinished !=
                 surface->ctx.framesProcessed) {
@@ -346,8 +348,6 @@ damage_thread(void *args)
                     data->egl.streamFlush(display->devDpy->eglDisplay,
                                           surface->ctx.eglStream);
                 }
-
-                pthread_mutex_lock(&surface->mutexFrameSync);
 
                 wlEglCreateFrameSync(surface);
 
@@ -361,6 +361,8 @@ damage_thread(void *args)
 
             // Otherwise, wait for sync to trigger
             else {
+                pthread_mutex_unlock(&surface->mutexFrameSync);
+
                 ok = (EGL_CONDITION_SATISFIED_KHR ==
                       data->egl.clientWaitSync(display->devDpy->eglDisplay,
                                                surface->ctx.damageThreadSync,


### PR DESCRIPTION
Reported by a static analysis tool:

```
  1. src/wayland-eglsurface.c:248:17: thread1_checks_field: Thread1 uses the value read from field "framesProcessed" in the condition "surface->ctx.framesFinished != surface->ctx.framesProcessed".It sees that the condition is true. Control is switched to Thread2.
  2. src/wayland-eglsurface.c:248:17: thread2_checks_field: Thread2 uses the value read from field "framesProcessed" in the condition "surface->ctx.framesFinished != surface->ctx.framesProcessed". It sees that the condition is true.
  3. src/wayland-eglsurface.c:255:17: thread2_acquires_lock: Thread2 acquires lock "WlEglSurfaceRec.mutexFrameSync".
  4. src/wayland-eglsurface.c:260:17: thread2_modifies_field: Thread2 sets "framesProcessed" to a new value. Note that this write can be reordered at runtime to occur before instructions that do not access this field within this locked region. After Thread2 leaves the critical section, control is switched back to Thread1.
  5. src/wayland-eglsurface.c:255:17: thread1_acquires_lock: Thread1 acquires lock "WlEglSurfaceRec.mutexFrameSync".
  6. src/wayland-eglsurface.c:260:17: thread1_overwrites_value_in_field: Thread1 sets "framesProcessed" to a new value. Now the two threads have an inconsistent view of "framesProcessed" and updates to fields correlated with "framesProcessed" may be lost.
  7. src/wayland-eglsurface.c:249:17: use_same_locks_for_read_and_modify: Guard the modification of "framesProcessed" and the read used to decide whether to modify "framesProcessed" with the same set of locks.
  #   258|
  #   259|                ok = wlEglSendDamageEvent(surface, queue);
  #   260|->              surface->ctx.framesProcessed++;
  #   261|
  #   262|                pthread_cond_signal(&surface->condFrameSync);
```

Fixes: 63e82b0 ("wayland-egl: avoid unnecessary commit")

---

I'm not familiar enough with this code to know if incrementing `framesProcessed` twice could be problematic. It not, feel free to ignore this PR.