### PR TITLE
egl-wayland: Use the correct coordinates when setting the damage region

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -280,8 +280,13 @@ wlEglSendDamageEvent(WlEglSurface *surface, struct wl_event_queue *queue)
         }
     }
 
-    wl_surface_damage(surface->wlSurface, 0, 0,
-                      surface->width, surface->height);
+    if (wl_surface_get_version(surface->wlSurface) >= WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION) {
+        wl_surface_damage_buffer(surface->wlSurface, 0, 0,
+                                 surface->width, surface->height);
+    } else {
+        wl_surface_damage(surface->wlSurface, 0, 0,
+                          INT32_MAX, INT32_MAX);
+    }
     wl_surface_commit(surface->wlSurface);
     surface->ctx.isAttached = EGL_TRUE;
 


### PR DESCRIPTION
Using the buffer width and height with wl_surface_damage is incorrect, as it expects surface-local coordinates. This causes issues when scaling using a viewport with an output region larger than the source region, as only a portion of the output region equal to the unscaled buffer size will be updated.

Use wl_surface_damage_buffer, when available, to set the damage region using buffer-local coordinates, otherwise, use wl_surface_damage with a sufficiently large width and height to declare the entire output region as damaged.

This is simpler than #50 while still fixing the underlying issue for clients using viewports.