### PR TITLE
Update to 1.1.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.64])
 
 m4_define([wayland_eglstream_major_version], [1])
 m4_define([wayland_eglstream_minor_version], [1])
-m4_define([wayland_eglstream_micro_version], [13])
+m4_define([wayland_eglstream_micro_version], [14])
 m4_define([wayland_eglstream_version],
           [wayland_eglstream_major_version.wayland_eglstream_minor_version.wayland_eglstream_micro_version])
 

--- a/include/wayland-external-exports.h
+++ b/include/wayland-external-exports.h
@@ -53,7 +53,7 @@
  #define WAYLAND_EXTERNAL_VERSION_MINOR                      0
 #endif
 
-#define WAYLAND_EXTERNAL_VERSION_MICRO                       13
+#define WAYLAND_EXTERNAL_VERSION_MICRO                       14
 
 
 #define EGL_EXTERNAL_PLATFORM_VERSION_MAJOR WAYLAND_EXTERNAL_VERSION_MAJOR

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('wayland-eglstream', 'c',
-        version : '1.1.13',
+        version : '1.1.14',
         default_options : [
           'buildtype=debugoptimized',
           'c_std=gnu99',

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -569,7 +569,6 @@ dmabuf_feedback_check_done(void *data, struct zwp_linux_dmabuf_feedback_v1 *dmab
     WlServerProtocols *protocols = (WlServerProtocols *)data;
     (void) dmabuf_feedback;
 
-    assert(protocols->devId != 0);
     drmDevice *drm_device;
     assert(getDeviceFromDevId);
     if (getDeviceFromDevId(protocols->devId, 0, &drm_device) == 0) {

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -431,12 +431,12 @@ registry_handle_global(void *data,
         display->wlStreamDpy = wl_registry_bind(registry,
                                                 name,
                                                 &wl_eglstream_display_interface,
-                                                version);
+                                                1);
     } else if (strcmp(interface, "wl_eglstream_controller") == 0) {
         display->wlStreamCtl = wl_registry_bind(registry,
                                                 name,
                                                 &wl_eglstream_controller_interface,
-                                                version);
+                                                version > 1 ? 2 : 1);
         display->wlStreamCtlVer = version;
     } else if (strcmp(interface, "zwp_linux_dmabuf_v1") == 0) {
         /*
@@ -460,7 +460,7 @@ registry_handle_global(void *data,
         display->wlDrmSyncobj = wl_registry_bind(registry,
                                                  name,
                                                  &wp_linux_drm_syncobj_manager_v1_interface,
-                                                 version);
+                                                 1);
     }
 }
 


### PR DESCRIPTION
This brings a few explicit sync fixes and bumps the version number to `1.1.14`. We can then make a new release tag containing explicit sync.

cc: @cubanismo @kbrenneman 