### PR TITLE
egl-wayland: Verify that errno is ETIME only on Linux

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -1206,7 +1206,9 @@ wlEglSurfaceCheckReleasePoints(WlEglDisplay *display, WlEglSurface *surface)
                            DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE,
                            &firstSignaled) != 0) {
         /* A timeout is the only type of error we expect here */
+#ifdef ETIME
         assert(errno == ETIME);
+#endif
         goto end;
     }
 


### PR DESCRIPTION
BSD variants do not define ETIME. So, the assert() call which verifies that errno is set to ETIME introduced in an earlier change could cause problems with debug builds on BSDs. This change adds preprocessor directives to limit that assertion to Linux.