### PR TITLE
egl-wayland: Add __NV_DISABLE_EXPLICIT_SYNC environment variable

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -1227,8 +1227,14 @@ static void wlEglCheckDriverSyncSupport(WlEglDisplay *display)
     EGLDisplay  dpy     = display->devDpy->eglDisplay;
     EGLint      attribs[5];
     uint32_t    tmpSyncobj;
+    const char *disableExplicitSyncStr = getenv("__NV_DISABLE_EXPLICIT_SYNC");
 
-    if (!display->supports_native_fence_sync) {
+    /*
+     * Don't enable explicit sync if requested by the user or if we do not have
+     * the necessary EGL extensions.
+     */
+    if ((disableExplicitSyncStr && !strcmp(disableExplicitSyncStr, "1")) ||
+        !display->supports_native_fence_sync) {
         return;
     }
 


### PR DESCRIPTION
There are still many application bugs caused by incorrect threading guarantees when running with explicit sync. This change implements a method for users to disable explicit sync manually for a particular application, in case there are issues with explicit sync.

Setting __NV_DISABLE_EXPLICIT_SYNC=1 will prevent the usage of explicit sync and fall back to the old method.

Tested disabling explicit sync on KDE, built on FreeBSD as well.