### PR TITLE
egl-wayland: Fix eglCreateSync and streamAcquireImage handling

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -1261,7 +1261,6 @@ static void wlEglCheckDriverSyncSupport(WlEglDisplay *display)
     attribs[4] = EGL_NONE;
     eglSync = display->data->egl.createSync(dpy, EGL_SYNC_NATIVE_FENCE_ANDROID,
                                             attribs);
-    close (syncFd);
 
     /* If the call failed then the driver version is recent enough */
     if (eglSync == EGL_NO_SYNC_KHR &&

--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -1126,7 +1126,6 @@ get_release_sync(WlEglDisplay *display, WlEglStreamImage *image)
     attribs[2] = EGL_NONE;
     eglSync = data->egl.createSync(dpy, EGL_SYNC_NATIVE_FENCE_ANDROID,
                                    attribs);
-    close (syncFd);
 destroy:
     drmSyncobjDestroy(display->drmFd, tmpSyncobj);
 
@@ -1292,9 +1291,7 @@ acquire_surface_image(WlEglDisplay *display, WlEglSurface *surface)
                                       surface->ctx.eglStream,
                                       &eglImage,
                                       acquireSync)) {
-        if (acquireSync != EGL_NO_SYNC_KHR) {
-            goto fail_destroy_sync;
-        }
+        goto fail_destroy_sync;
     }
 
     pthread_mutex_lock(&surface->ctx.streamImagesMutex);


### PR DESCRIPTION
This fixes two issues:
* eglCreateSync takes ownership of the fd passed to it, so we shoul not close the fd after passing it in.
* eglStreamAcquireImage's failure case only bails out of the function if acquireSync is valid, which is not the case when explicit sync is not in use.