### PR TITLE
Add an explicit dependency on the EGL headers.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ libnvidia_egl_wayland_la_CFLAGS =       \
 # Required library flags
 libnvidia_egl_wayland_la_CFLAGS +=      \
     $(PTHREAD_CFLAGS)                   \
+    $(EGL_CFLAGS)                       \
     $(EGL_EXTERNAL_PLATFORM_CFLAGS)     \
     $(WAYLAND_CFLAGS)                   \
     $(LIBDRM_CFLAGS)                    \

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,7 @@ AX_PTHREAD()
 AC_CHECK_LIB([dl], [dlsym],
              [],
              [AC_MSG_ERROR("dlsym is needed to compile wayland-egldisplay")])
+PKG_CHECK_MODULES([EGL_HEADERS], [egl >= 1.5 egl < 2])
 PKG_CHECK_MODULES([EGL_EXTERNAL_PLATFORM], [eglexternalplatform >= ${EGL_EXTERNAL_PLATFORM_MIN_VERSION} eglexternalplatform < ${EGL_EXTERNAL_PLATFORM_MAX_VERSION}])
 PKG_CHECK_MODULES([WAYLAND], [wayland-server wayland-client wayland-egl-backend >= 3])
 PKG_CHECK_MODULES([LIBDRM], [libdrm])

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,8 @@ wayland_eglstream_major_version = ver_arr[0]
 wayland_eglstream_minor_version = ver_arr[1]
 wayland_eglstream_micro_version = ver_arr[2]
 
+egl = dependency('egl', version : ['>=1.5', '<2'])
+egl_headers = egl.partial_dependency(includes : true, compile_args : true)
 eglexternalplatform = dependency('eglexternalplatform', version : ['>=1.1', '<2'])
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')

--- a/src/meson.build
+++ b/src/meson.build
@@ -73,6 +73,7 @@ src += code.process(wl_drm_syncobj_xml)
 egl_wayland = library('nvidia-egl-wayland',
     src,
     dependencies : [
+        egl_headers,
         eglexternalplatform,
         wayland_server,
         wayland_client,


### PR DESCRIPTION
This just adds a dependency on the EGL headers (but not the libraries) to the build scripts.

I doubt that in practice we'll have to worry about egl.h and friends being in some strange location, so this mainly just provides a clearer error message if they're missing.