### PR TITLE
Provide damage rectangles to wl_surface to avoid damaging entire surface when only parts of it need to be

### DIFF
--- a/include/wayland-eglsurface-internal.h
+++ b/include/wayland-eglsurface-internal.h
@@ -206,7 +206,9 @@ EGLBoolean
 wlEglSurfaceCheckReleasePoints(WlEglDisplay *display, WlEglSurface *surface);
 
 EGLBoolean wlEglSendDamageEvent(WlEglSurface *surface,
-                                struct wl_event_queue *queue);
+                                struct wl_event_queue *queue,
+                                EGLint *rects,
+                                EGLint n_rects);
 
 void wlEglCreateFrameSync(WlEglSurface *surface);
 EGLint wlEglWaitFrameSync(WlEglSurface *surface);

--- a/src/wayland-eglswap.c
+++ b/src/wayland-eglswap.c
@@ -147,7 +147,7 @@ EGLBoolean wlEglSwapBuffersWithDamageHook(EGLDisplay eglDisplay, EGLSurface eglS
             surface->ctx.framesProduced++;
         } else {
             wlEglCreateFrameSync(surface);
-            res = wlEglSendDamageEvent(surface, surface->wlEventQueue);
+            res = wlEglSendDamageEvent(surface, surface->wlEventQueue, rects, n_rects);
             wlEglSurfaceCheckReleasePoints(display, surface);
         }
     }
@@ -434,7 +434,7 @@ EGLBoolean wlEglPostPresentExport2(WlEglSurface *surface,
         surface->ctx.framesProduced++;
     } else {
         wlEglCreateFrameSync(surface);
-        res = wlEglSendDamageEvent(surface, surface->wlEventQueue);
+        res = wlEglSendDamageEvent(surface, surface->wlEventQueue, NULL, 0);
     }
 
     // Release wlEglSurface lock.


### PR DESCRIPTION
This is a rebase of a single commit from #50 that provides damage rectangles for wl_surfaces so the compositor knows which parts of the surfaces are damaged instead of just always damaging the surface as a whole.

I set @chergert as commit author since the changes of this commit are identical to his.

I didn't include the part that supports the damage_thread yet from #50 because [the damage thread is apparently gone when using explicit sync](https://github.com/NVIDIA/egl-wayland/pull/50#issuecomment-2305484091), this seems to also be sufficient to get applications such as Nautilus to only redraw the parts they need to, and this keeps the diff smaller. (In https://github.com/NVIDIA/egl-wayland/pull/50#issuecomment-2302748546 I also rebased the other commit, but we can add that separately if it still turns out to be useful.)