### PR TITLE
A couple of build fixes

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -568,9 +568,10 @@ static void
 dmabuf_feedback_check_done(void *data, struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback)
 {
     WlServerProtocols *protocols = (WlServerProtocols *)data;
+    drmDevice *drm_device;
+
     (void) dmabuf_feedback;
 
-    drmDevice *drm_device;
     assert(getDeviceFromDevId);
     if (getDeviceFromDevId(protocols->devId, 0, &drm_device) == 0) {
         if (drm_device->available_nodes & (1 << DRM_NODE_RENDER)) {

--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -41,7 +41,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <errno.h>
-#include <libdrm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include <sys/stat.h>
 #include <xf86drm.h>
 #include <stdio.h>


### PR DESCRIPTION
This is a couple of minor build fixes.

In wayland-eglsurface.c, it tries to include `<libdrm/drm_fourcc.h>`, but there's no actual requirement that `drm_fourcc.h` should be in a `libdrm` subdirectory (even if it usually is). We already use pkg-config to add the appropriate include path for libdrm, so there's no need to hard-code a subdirectory for it.

The other just moves a declaration to the top of a function, since older compilers don't let you mix declarations and code.