### PR TITLE
Use INT32_MAX for wl_surface_damage

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -301,7 +301,7 @@ wlEglSendDamageEvent(WlEglSurface *surface,
             wl_surface_damage_buffer(surface->wlSurface, rect[0], inv_y, rect[2], rect[3]);
         }
     } else {
-        wl_surface_damage(surface->wlSurface, 0, 0, UINT32_MAX, UINT32_MAX);
+        wl_surface_damage(surface->wlSurface, 0, 0, INT32_MAX, INT32_MAX);
     }
 
 


### PR DESCRIPTION
This is a follow-up to #138, to use INT32_MAX instead of UINT32_MAX for the wl_surface::damage request, since the protocol defines that as taking a signed int.