### PR TITLE
egl-wayland: The `image` parameter of `send_explicit_sync_points` should not be NULL.

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -268,6 +268,8 @@ wlEglSendDamageEvent(WlEglSurface *surface,
         if (image) {
             surface->ctx.currentBuffer = image->buffer;
             image->attached = EGL_TRUE;
+        } else {
+            return EGL_FALSE;
         }
 
         /*


### PR DESCRIPTION
The `send_explicit_sync_points` function assumes that none of its three parameters are NULL and does not perform NULL pointer checks. However, during runtime, the `image` parameter can potentially be NULL, leading to a crash.

Attached crash log.

[crash_log.txt](https://github.com/user-attachments/files/16924811/crash_log.txt)
