### PR TITLE
egl-wayland: fix device name case where only wl_drm exists

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -634,7 +634,6 @@ registry_handle_global_check_protocols(
 
     if ((strcmp(interface, "wl_drm") == 0) && (version >= 2)) {
         protocols->wlDrm = wl_registry_bind(registry, name, &wl_drm_interface, 2);
-        wl_drm_add_listener(protocols->wlDrm, &drmListener, protocols);
     }
 }
 
@@ -831,6 +830,12 @@ static bool getServerProtocolsInfo(struct wl_display *nativeDpy,
                 wl_display_roundtrip_queue(nativeDpy, queue);
                 zwp_linux_dmabuf_feedback_v1_destroy(default_feedback);
             }
+        }
+
+        /* If we didn't get a name through linux_dmabuf then fall back to wl_drm */
+        if (!protocols->drm_name && protocols->wlDrm) {
+            wl_drm_add_listener(protocols->wlDrm, &drmListener, protocols);
+            wl_display_roundtrip_queue(nativeDpy, queue);
         }
 
         /* Check that one of our two protocols provided the device name */


### PR DESCRIPTION
This fixes a problem in commit 6355c16 where we do not properly wait for a roundtrip to get the wl_drm name, which can lead to failing to initialize and falling back to another ICD. This fix also properly prioritizes the device provided by dmabuf feedback over the wl_drm name, only using wl_drm if dmabuf did not provide anything.