### PR TITLE
Add ICD json file

### DIFF
--- a/src/10_nvidia_wayland.json
+++ b/src/10_nvidia_wayland.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libnvidia-egl-wayland.so.1"
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -86,3 +86,6 @@ egl_wayland = library('nvidia-egl-wayland',
     version : meson.project_version(),
     install : true,
 )
+
+install_data('10_nvidia_wayland.json',
+    install_dir: '@0@/egl/egl_external_platform.d'.format(get_option('datadir')))


### PR DESCRIPTION
For `egl-x11` we are shipping the ICD json loaders as part of the source. For `egl-wayland` we are not.

Also make sure the json file has the same name as the one that is shipped with the Nvidia driver.