### PR TITLE
egl-wayland: enable CI with github actions

### DIFF
--- a/.github/workflows/arch-build.yml
+++ b/.github/workflows/arch-build.yml
@@ -1,0 +1,16 @@
+name: Arch Build
+on: [push, pull_request]
+jobs:
+  Meson-Build:
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pacman --noconfirm -Syy
+      - run: pacman --noconfirm -S wayland-protocols libdrm libglvnd pkgconf
+      - run: pacman --noconfirm -S wayland eglexternalplatform
+      - run: pacman --noconfirm -S meson ninja gcc
+      - run: meson build
+      - run: ninja -C build
+      - run: ninja -C build install

--- a/.github/workflows/autoconf-build.yml
+++ b/.github/workflows/autoconf-build.yml
@@ -1,0 +1,14 @@
+name: Autotools GCC Build
+on: [push, pull_request]
+jobs:
+  Meson-Build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt update
+      - run: sudo apt install -y wayland-protocols libdrm-dev libegl-dev
+      - run: sudo apt install -y libwayland-dev libwayland-egl-backend-dev eglexternalplatform-dev
+      - run: sudo apt install -y meson ninja-build gcc
+      - run: ./autogen.sh
+      - run: make
+      - run: sudo make install

--- a/.github/workflows/meson-build.yml
+++ b/.github/workflows/meson-build.yml
@@ -1,0 +1,14 @@
+name: Meson GCC Build
+on: [push, pull_request]
+jobs:
+  Meson-Build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt update
+      - run: sudo apt install -y wayland-protocols libdrm-dev libegl-dev
+      - run: sudo apt install -y libwayland-dev libwayland-egl-backend-dev eglexternalplatform-dev
+      - run: sudo apt install -y meson ninja-build gcc
+      - run: meson build
+      - run: ninja -C build
+      - run: sudo ninja -C build install

--- a/.github/workflows/meson-llvm-build.yml
+++ b/.github/workflows/meson-llvm-build.yml
@@ -1,0 +1,17 @@
+name: Meson LLVM Build
+on: [push, pull_request]
+jobs:
+  Meson-Build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt update
+      - run: sudo apt install -y wayland-protocols libdrm-dev libegl-dev
+      - run: sudo apt install -y libwayland-dev libwayland-egl-backend-dev eglexternalplatform-dev
+      - run: sudo apt install -y meson ninja-build clang
+      - name: meson build
+        run: meson build
+        env:
+          CC: clang
+      - run: ninja -C build
+      - run: sudo ninja -C build install


### PR DESCRIPTION
This enables CI for github actions builds, aimed for helping verify new pull requests. This adds tests for the meson and autotools builds on ubuntu 24.04. Other distros are apparently not supported by default so we aren't able to expand testing this way.

We will need to add things like other distro support, FreeBSD CI, etc in the future but this is a good start for now.