### PR TITLE
egl-wayland: Fix use after free at library teardown

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -729,10 +729,10 @@ static EGLBoolean terminateDisplay(WlEglDisplay *display, EGLBoolean globalTeard
      * destroy the display connection itself */
     wlEglDestroyAllSurfaces(display);
 
-    wlEglDestroyFormatSet(&display->formatSet);
-    wlEglDestroyFeedback(&display->defaultFeedback);
-
     if (!globalTeardown || display->ownNativeDpy) {
+        wlEglDestroyFormatSet(&display->formatSet);
+        wlEglDestroyFeedback(&display->defaultFeedback);
+
         if (display->wlRegistry) {
             wl_registry_destroy(display->wlRegistry);
             display->wlRegistry = NULL;


### PR DESCRIPTION
This patch extends the hack described [here](https://github.com/NVIDIA/egl-wayland/blob/c10c5300483a8ec975e64e5d76c0fb00ac94e026/src/wayland-egldisplay.c#L692) to wlEglDestroyFeedback which might destroy a zwp_linux_dmabuf_feedback_v1 object.

I encountered a segmentation fault at termination of the game celeste because of this