### PR TITLE
egl-wayland: Handle failure to acquire image in wlEglSendDamageEvent

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -265,10 +265,12 @@ wlEglSendDamageEvent(WlEglSurface *surface,
         }
 
         image = pop_acquired_image(surface);
-        if (image) {
-            surface->ctx.currentBuffer = image->buffer;
-            image->attached = EGL_TRUE;
+        if (!image) {
+            return EGL_FALSE;
         }
+
+        surface->ctx.currentBuffer = image->buffer;
+        image->attached = EGL_TRUE;
 
         /*
          * Send our explicit sync acquire and release points. This needs to be done


### PR DESCRIPTION
The image parameter of send_explicit_sync_points is assumed not to be null, however this is a case the rest of the code handles. This causes sporadic problems on KDE when running overnight as the image will not be valid at some point, causing us to crash.

Fixes #143
