### PR TITLE
Check duplicate native surfaces

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -2843,15 +2843,14 @@ EGLSurface wlEglCreatePlatformWindowSurfaceHook(EGLDisplay dpy,
     return surface;
 
 fail:
-    if (surface->drmSyncobjHandle) {
-        drmSyncobjDestroy(display->drmFd, surface->drmSyncobjHandle);
-    }
-
     if (drmSyncobjFd > 0) {
         close(drmSyncobjFd);
     }
 
     if (surface) {
+        if (surface->drmSyncobjHandle) {
+            drmSyncobjDestroy(display->drmFd, surface->drmSyncobjHandle);
+        }
         wlEglDestroySurface(display, surface);
     }
 


### PR DESCRIPTION
By the EGL spec, you're not allowed to create more than one EGLSurface from the same native window/pixmap. Currently, egl-wayland only partially checks for that, but you can still cause problems in a slightly more roundabout way.

While egl-wayland does check if the app tries to create a second EGLSurface from the same `wl_egl_window`, it's still possible to create more than one EGLSurface from the same `wl_surface`. Since `wl_egl_window_create` itself doesn't check for duplicates, you can create more than one `wl_egl_window` from the same `wl_surface`, and then create an EGLSurface for each.

With this change, egl-wayland will scan the list of EGLSurfaces to check if any of them use the same underlying `wl_surface`, and if it finds one, it'll fail eglCreateWindowSurface with EGL_BAD_ALLOC.

I also fixed a segfault that it would run into in early-failure cases like this one, where it hasn't allocated the `WlEglSurface` yet, but the cleanup code tries to dereference it.