### PR TITLE
egl-wayland: bump version to 1.1.18

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.64])
 
 m4_define([wayland_eglstream_major_version], [1])
 m4_define([wayland_eglstream_minor_version], [1])
-m4_define([wayland_eglstream_micro_version], [17])
+m4_define([wayland_eglstream_micro_version], [18])
 m4_define([wayland_eglstream_version],
           [wayland_eglstream_major_version.wayland_eglstream_minor_version.wayland_eglstream_micro_version])
 

--- a/include/wayland-external-exports.h
+++ b/include/wayland-external-exports.h
@@ -53,7 +53,7 @@
  #define WAYLAND_EXTERNAL_VERSION_MINOR                      0
 #endif
 
-#define WAYLAND_EXTERNAL_VERSION_MICRO                       17
+#define WAYLAND_EXTERNAL_VERSION_MICRO                       18
 
 
 #define EGL_EXTERNAL_PLATFORM_VERSION_MAJOR WAYLAND_EXTERNAL_VERSION_MAJOR

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('wayland-eglstream', 'c',
-        version : '1.1.17',
+        version : '1.1.18',
         default_options : [
           'buildtype=debugoptimized',
           'c_std=gnu99',


### PR DESCRIPTION
Since 1.1.17 was just posted to correspond with the 565 release this bumps the latest development version to 1.1.18.