### PR TITLE
Fix read return value check in buffer_release_thread

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -500,7 +500,7 @@ buffer_release_thread(void *args)
         }
 
         if (pfds[1].revents & POLLIN) {
-            if (read(pfds[1].fd, &cmd, sizeof(cmd) != sizeof(cmd))) {
+            if (read(pfds[1].fd, &cmd, sizeof(cmd)) != sizeof(cmd)) {
                 /* Reading an event from the app side failed. Bail. */
                 wl_display_cancel_read(wlDpy);
                 return NULL;


### PR DESCRIPTION
Previously, we were reading 0 bytes and were passing uninitialized value to `switch`. Likely, not much changed in practice (all codepaths were just terminating the thread, regardless of the success of the `read`), but now we don't trigger undefined behavior.