### PR TITLE
Fix reporting EGL_EXT_present_opaque

### DIFF
--- a/include/wayland-egldisplay.h
+++ b/include/wayland-egldisplay.h
@@ -182,6 +182,8 @@ typedef struct WlEglDisplayRec {
     WlEglDmaBufFeedback defaultFeedback;
 
     EGLBoolean primeRenderOffload;
+
+    char *extensionString;
 } WlEglDisplay;
 
 typedef struct WlEventQueueRec {

--- a/include/wayland-egldisplay.h
+++ b/include/wayland-egldisplay.h
@@ -223,6 +223,7 @@ EGLBoolean wlEglGetConfigAttribHook(EGLDisplay dpy,
 EGLBoolean wlEglQueryDisplayAttribHook(EGLDisplay dpy,
                                        EGLint name,
                                        EGLAttrib *value);
+const char* wlEglQueryStringHook(EGLDisplay dpy, EGLint name);
 
 
 EGLBoolean wlEglIsWaylandDisplay(void *nativeDpy);

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -1646,6 +1646,32 @@ EGLBoolean wlEglQueryDisplayAttribHook(EGLDisplay dpy,
     return ret;
 }
 
+const char* wlEglQueryStringHook(EGLDisplay dpy, EGLint name)
+{
+    WlEglDisplay *display = wlEglAcquireDisplay(dpy);
+    const char *str = NULL;
+
+    if (!display) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&display->mutex);
+
+    if (name == EGL_EXTENSIONS)
+    {
+        str = display->extensionString;
+    }
+    if (str == NULL)
+    {
+        str = display->data->egl.queryString(display->devDpy->eglDisplay, name);
+    }
+
+    pthread_mutex_unlock(&display->mutex);
+    wlEglReleaseDisplay(display);
+
+    return str;
+}
+
 EGLBoolean wlEglDestroyAllDisplays(WlEglPlatformData *data)
 {
     WlEglDisplay *display, *next;
@@ -1724,13 +1750,13 @@ const char* wlEglQueryStringExport(void *data,
                                    exts)) {
                 if (wlEglFindExtension("EGL_KHR_stream_cross_process_fd",
                                        exts)) {
-                    res = "EGL_EXT_present_opaque EGL_WL_bind_wayland_display "
+                    res = "EGL_WL_bind_wayland_display "
                         "EGL_WL_wayland_eglstream";
                 } else if (wlEglFindExtension("EGL_NV_stream_consumer_eglimage",
                                               exts) &&
                            wlEglFindExtension("EGL_MESA_image_dma_buf_export",
                                               exts)) {
-                    res = "EGL_EXT_present_opaque EGL_WL_bind_wayland_display";
+                    res = "EGL_WL_bind_wayland_display";
                 }
             }
         }

--- a/src/wayland-external-exports.c
+++ b/src/wayland-external-exports.c
@@ -50,6 +50,7 @@ static const WlEglHook wlEglHooksMap[] = {
     { "eglInitialize",                     wlEglInitializeHook },
     { "eglQueryDisplayAttribEXT",          wlEglQueryDisplayAttribHook },
     { "eglQueryDisplayAttribKHR",          wlEglQueryDisplayAttribHook },
+    { "eglQueryString",                    wlEglQueryStringHook },
     { "eglQuerySurface",                   wlEglQuerySurfaceHook },
     { "eglQueryWaylandBufferWL",           wlEglQueryNativeResourceHook },
     { "eglSwapBuffers",                    wlEglSwapBuffersHook },


### PR DESCRIPTION
This removes `EGL_EXT_present_opaque` from the `EGL_EXT_PLATFORM_DISPLAY_EXTENSIONS` query, and instead adds a hook for `eglQueryString` to report it.

Any extensions in `EGL_EXT_PLATFORM_DISPLAY_EXTENSIONS` get added to *every* EGLDisplay, not just the ones that belong to egl-wayland. That's what we want for things like `EGL_WL_bind_wayland_display`, which is implemented in egl-wayland, but used in a compositor (generally with a device or GBM-based display).

For `EGL_EXT_present_opaque`, we need to report that through an `eglQueryString` hook instead. Unfortunately, current drivers won't call an eglQueryString hook, so without an updated driver, this will remove `EGL_EXT_present_opaque` from Wayland EGLDisplays as well. But, that's still better than advertising it on non-Wayland EGLDisplays where it doesn't work.