### PR TITLE
egl-wayland: Fix libdrm loading when wl_drm is not available

### DIFF
--- a/include/wayland-eglhandle.h
+++ b/include/wayland-eglhandle.h
@@ -28,6 +28,7 @@
 #include "wayland-external-exports.h"
 #include "wayland-egl-ext.h"
 #include <pthread.h>
+#include <xf86drm.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -137,6 +138,10 @@ typedef struct WlEglPlatformDataRec {
 
     /* pthread key for TLS */
     pthread_key_t tlsKey;
+
+    /* libdrm Handle */
+    void *libdrmDlHandle;
+    int (*getDeviceFromDevId)(dev_t dev_id, uint32_t flags, drmDevice **device);
 } WlEglPlatformData;
 
 


### PR DESCRIPTION
If the compositor does not support wl_drm and we fail to get the drmGetDeviceFromDevId symbol then the driver load will fail. This happens with steam due to it hijacking dlopen/dlsym. This change has us directly dlopen libdrm and get a symbol from it instead of relying on RTLD_DEFAULT.