### PR TITLE
fix: cap drmSyncobjTimelineWait timeout to 100ms to prevent deadlock

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -1217,7 +1217,24 @@ wlEglSurfaceCheckReleasePoints(WlEglDisplay *display, WlEglSurface *surface)
      * Not all compositors will hold 3 and 4 indefinitely, although Kwin does
      * at certain times.
      */
-    timeout = numSyncPoints >= 3 ? INT64_MAX : 0;
+    /*
+     * FIX: Cap the timeout to 100ms instead of waiting indefinitely.
+     *
+     * When the compositor is blocked on the kernel-side nvkms_lock (held by a
+     * client GEM buffer allocation), it cannot signal release points for
+     * previously-committed buffers.  With INT64_MAX, the client blocks forever
+     * waiting for those release points, creating a circular deadlock:
+     *
+     *   Client holds nvkms_lock (via GEM alloc) -> compositor blocks on flip
+     *   -> compositor can't release buffers -> client waits INT64_MAX here
+     *   -> client can't release nvkms_lock -> system freeze
+     *
+     * A 100ms timeout lets the client back off and retry, breaking the
+     * deadlock while still allowing normal explicit sync to function.
+     *
+     * See: https://github.com/NVIDIA/egl-wayland/issues/XXX
+     */
+    timeout = numSyncPoints >= 3 ? 100000000LL /* 100ms in nanoseconds */ : 0;
 
     /*
      * The Linux docs say that DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE should be


### PR DESCRIPTION
## Summary

This PR caps the `drmSyncobjTimelineWait` timeout from `INT64_MAX` to 100ms when waiting for buffer release points, preventing a system-wide deadlock on NVIDIA GPUs with Wayland compositors using explicit sync.

## Problem

When the compositor is blocked on the kernel-side `nvkms_lock` (held by a client's GEM buffer allocation), it cannot signal release points for previously-committed buffers. With `INT64_MAX` timeout, the client blocks forever waiting for those release points, creating a circular deadlock:

```
Client holds nvkms_lock (via GEM alloc)
  → Compositor blocks on nvkms_lock (page flip)
    → Compositor can't release buffers
      → Client waits INT64_MAX here
        → Client can't release nvkms_lock
          → System freeze
```

## Solution

Replace `INT64_MAX` with a 100ms timeout so the client can back off and retry, breaking the deadlock while preserving normal explicit sync behavior.

## Testing

- **Hardware**: NVIDIA discrete GPU (driver 590.48.01) + Intel Meteor Lake iGPU
- **OS**: Gentoo Linux, kernel 7.0.0-rc1
- **Compositor**: Niri (Smithay-based), dual 2560x1440 monitors
- **Application**: PyCharm 2026.1 EAP with JetBrains Runtime WLToolkit (native Wayland)

Before this fix: System would freeze within seconds of launching PyCharm (7/9 attempts).
After this fix: PyCharm runs stable with explicit sync enabled, no freezes.

## Workaround

Setting `__NV_DISABLE_EXPLICIT_SYNC=1` also prevents the freeze by disabling explicit sync entirely, but this fix allows explicit sync to remain enabled.

## Related

- Affects NVIDIA 590.x with Wayland compositors using explicit sync
- Root cause is `nvkms_lock` serialization in the kernel module, but this egl-wayland fix breaks the deadlock cycle