### PR TITLE
egl-wayland: Prefer render node over primary node

### DIFF
--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -949,6 +949,7 @@ EGLDisplay wlEglGetPlatformDisplayExport(void *data,
     EGLBoolean usePrimeRenderOffload = EGL_FALSE;
     EGLBoolean isServerNV;
     const char *drmName = NULL;
+    const char *devExts = NULL;
 
     if (platform != EGL_PLATFORM_WAYLAND_EXT) {
         wlEglSetError(data, EGL_BAD_PARAMETER);
@@ -1191,13 +1192,24 @@ EGLDisplay wlEglGetPlatformDisplayExport(void *data,
     WL_LIST_INIT(&display->wlEglSurfaceList);
 
     /* Get the DRM device in use */
-    drmName = display->data->egl.queryDeviceString(display->devDpy->eglDevice,
-                                                   EGL_DRM_DEVICE_FILE_EXT);
-    if (!drmName) {
+    devExts = display->data->egl.queryDeviceString(display->devDpy->eglDevice, EGL_EXTENSIONS);
+    if (!devExts) {
         goto fail;
     }
 
-    display->drmFd = open(drmName, O_RDWR | O_CLOEXEC);
+    display->drmFd = -1;
+    if (wlEglFindExtension("EGL_EXT_device_drm_render_node", devExts)) {
+        drmName = display->data->egl.queryDeviceString(display->devDpy->eglDevice, EGL_DRM_RENDER_NODE_FILE_EXT);
+        if (drmName) {
+            display->drmFd = open(drmName, O_RDWR | O_CLOEXEC);
+        }
+    }
+    if (display->drmFd < 0 && wlEglFindExtension("EGL_EXT_device_drm", devExts)) {
+        drmName = display->data->egl.queryDeviceString(display->devDpy->eglDevice, EGL_DRM_DEVICE_FILE_EXT);
+        if (drmName) {
+            display->drmFd = open(drmName, O_RDWR | O_CLOEXEC);
+        }
+    }
     if (display->drmFd < 0) {
         goto fail;
     }


### PR DESCRIPTION
This fixes an issue where the user has permissions for the render node but not the primary node.

This is an issue I encountered in a headless setup where the render node is readable and writeable by every user while the primary node is only accessible by root (because its permissions are managed by systemd-logind in a non-headless setup)