### PR TITLE
wayland-eglstream: release external API lock before calling device EGL

### DIFF
--- a/src/wayland-eglstream.c
+++ b/src/wayland-eglstream.c
@@ -89,14 +89,16 @@ EGLStreamKHR wlEglCreateStreamAttribHook(EGLDisplay dpy,
     }
 
     if (err != EGL_SUCCESS) {
-        goto fail;
+        goto fail_unlock;
     }
 
     wlStream = wl_eglstream_display_get_stream(wlStreamDpy, resource);
     if (wlStream == NULL) {
         err = EGL_BAD_ACCESS;
-        goto fail;
+        goto fail_unlock;
     }
+
+    wlExternalApiUnlock();
 
     if (wlStream->eglStream != EGL_NO_STREAM_KHR ||
         wlStream->handle == -1) {
@@ -237,12 +239,11 @@ EGLStreamKHR wlEglCreateStreamAttribHook(EGLDisplay dpy,
     wlStream->eglStream = stream;
     wlStream->handle = -1;
 
-    wlExternalApiUnlock();
-
     return stream;
 
-fail:
+fail_unlock:
     wlExternalApiUnlock();
+fail:
     wlEglSetError(data, err);
     return EGL_NO_STREAM_KHR;
 }


### PR DESCRIPTION
The following code path can potentially produce a deadlock:
- wlEglCreateStreamAttribHook()
- External API lock acquired on line 82.
- Calls internal device driver EGL `createStreamAttrib` on line 201.
- This internal device driver can potentially invoke another external API like `wlEglAcquireDisplay`.

As `wlMutex` is initialized with `PTHREAD_MUTEX_ERRORCHECK` the deadlock on the same thread will crash the application.

There's no point holding the lock once `wlStreamDpy` and `wlStream` are validated. Any device EGL that invokes platform EGL again would be doing their own validation (taking the lock in the process).

Reference:
- https://github.com/telegramdesktop/tdesktop/issues/29965
- Fixes #192