### PR TITLE
Fix fd leaks in linux-dmabuf feedback handling

### DIFF
--- a/include/wayland-egldisplay.h
+++ b/include/wayland-egldisplay.h
@@ -129,7 +129,6 @@ typedef struct WlEglDisplayRec {
     EGLBoolean         ownNativeDpy;
     struct wl_display *nativeDpy;
 
-    struct wl_registry             *wlRegistry;
     struct wl_eglstream_display    *wlStreamDpy;
     struct wl_eglstream_controller *wlStreamCtl;
     struct zwp_linux_dmabuf_v1     *wlDmaBuf;

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -743,10 +743,6 @@ static EGLBoolean terminateDisplay(WlEglDisplay *display, EGLBoolean globalTeard
         wlEglDestroyFormatSet(&display->formatSet);
         wlEglDestroyFeedback(&display->defaultFeedback);
 
-        if (display->wlRegistry) {
-            wl_registry_destroy(display->wlRegistry);
-            display->wlRegistry = NULL;
-        }
         if (display->wlStreamDpy) {
             wl_eglstream_display_destroy(display->wlStreamDpy);
             display->wlStreamDpy = NULL;
@@ -1325,6 +1321,7 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
     WlEglDisplay      *display = wlEglAcquireDisplay(dpy);
     WlEglPlatformData *data    = NULL;
     struct wl_display *wrapper = NULL;
+    struct wl_registry *wlRegistry = NULL;
     EGLint             err     = EGL_SUCCESS;
     int                ret     = 0;
     const char *dev_exts = NULL;
@@ -1388,9 +1385,9 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
     /* Listen to wl_registry events and make a roundtrip in order to find the
      * wl_eglstream_display and/or zwp_linux_dmabuf_v1 global object
      */
-    display->wlRegistry = wl_display_get_registry(wrapper);
+    wlRegistry = wl_display_get_registry(wrapper);
     wl_proxy_wrapper_destroy(wrapper); /* Done with wrapper */
-    ret = wl_registry_add_listener(display->wlRegistry,
+    ret = wl_registry_add_listener(wlRegistry,
                                    &registry_listener,
                                    display);
     if (ret == 0) {
@@ -1462,9 +1459,9 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
         display->defaultFeedback.wlDmaBufFeedback = NULL;
     }
 
-    if (display->wlRegistry) {
-        wl_registry_destroy(display->wlRegistry);
-        display->wlRegistry = NULL;
+    if (wlRegistry) {
+        wl_registry_destroy(wlRegistry);
+        wlRegistry = NULL;
     }
 
     if (major != NULL) {
@@ -1479,6 +1476,9 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
     return EGL_TRUE;
 
 fail:
+    if (wlRegistry) {
+        wl_registry_destroy(wlRegistry);
+    }
     terminateDisplay(display, EGL_FALSE);
     if (err != EGL_SUCCESS) {
         wlEglSetError(data, err);

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -385,6 +385,15 @@ dmabuf_feedback_format_table(void *data,
     (void) dmabuf_feedback;
 
     assert(size % sizeof(WlEglDmaBufFormatTableEntry) == 0);
+
+    /* On a feedback resend, unmap the previous table before replacing it. */
+    if (feedback->formatTable.entry &&
+        feedback->formatTable.entry != MAP_FAILED &&
+        feedback->formatTable.len > 0) {
+        munmap((void *)feedback->formatTable.entry,
+               sizeof(feedback->formatTable.entry[0]) * feedback->formatTable.len);
+    }
+
     feedback->formatTable.len = size / sizeof(WlEglDmaBufFormatTableEntry);
 
     feedback->formatTable.entry =
@@ -590,8 +599,10 @@ dmabuf_feedback_check_format_table(void *data,
 {
     (void) data;
     (void) dmabuf_feedback;
-    (void) fd;
     (void) size;
+
+    /* This probe only cares about main_device; don't leak the table fd. */
+    close(fd);
 }
 
 static const struct zwp_linux_dmabuf_feedback_v1_listener dmabuf_feedback_check_listener = {

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -1450,10 +1450,21 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
      * resend feedback on every scanout-candidacy change), until the process
      * hits RLIMIT_NOFILE. Destroy the proxy now; per-surface feedback keeps
      * handling dynamic changes on queues that are dispatched at swap time.
+     *
+     * The registry is likewise only needed to discover globals during
+     * initialization; destroying it stops runtime global announcements from
+     * accumulating on the queue. The queue itself is kept, unlike in
+     * egl-wayland2: wlDmaBuf and other long-lived proxies stay attached to
+     * it, and the EGLStream path still does swap-interval roundtrips on it.
      */
     if (display->defaultFeedback.wlDmaBufFeedback) {
         zwp_linux_dmabuf_feedback_v1_destroy(display->defaultFeedback.wlDmaBufFeedback);
         display->defaultFeedback.wlDmaBufFeedback = NULL;
+    }
+
+    if (display->wlRegistry) {
+        wl_registry_destroy(display->wlRegistry);
+        display->wlRegistry = NULL;
     }
 
     if (major != NULL) {

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -151,12 +151,25 @@ typedef caddr_t pointer_t;
 typedef void *pointer_t;
 #endif
 
+static void
+wlEglFeedbackUnmapFormatTable(WlEglDmaBufFeedback *feedback)
+{
+    if (feedback->formatTable.entry &&
+        feedback->formatTable.entry != MAP_FAILED &&
+        feedback->formatTable.len > 0) {
+        munmap((pointer_t)feedback->formatTable.entry,
+               sizeof(feedback->formatTable.entry[0]) * feedback->formatTable.len);
+    }
+
+    feedback->formatTable.entry = NULL;
+    feedback->formatTable.len = 0;
+}
+
 void
 wlEglDestroyFeedback(WlEglDmaBufFeedback *feedback)
 {
     wlEglFeedbackResetTranches(feedback);
-    munmap((pointer_t)feedback->formatTable.entry,
-           sizeof(feedback->formatTable.entry[0]) * feedback->formatTable.len);
+    wlEglFeedbackUnmapFormatTable(feedback);
 
     if (feedback->wlDmaBufFeedback) {
         zwp_linux_dmabuf_feedback_v1_destroy(feedback->wlDmaBufFeedback);
@@ -387,12 +400,7 @@ dmabuf_feedback_format_table(void *data,
     assert(size % sizeof(WlEglDmaBufFormatTableEntry) == 0);
 
     /* On a feedback resend, unmap the previous table before replacing it. */
-    if (feedback->formatTable.entry &&
-        feedback->formatTable.entry != MAP_FAILED &&
-        feedback->formatTable.len > 0) {
-        munmap((void *)feedback->formatTable.entry,
-               sizeof(feedback->formatTable.entry[0]) * feedback->formatTable.len);
-    }
+    wlEglFeedbackUnmapFormatTable(feedback);
 
     feedback->formatTable.len = size / sizeof(WlEglDmaBufFormatTableEntry);
 
@@ -1457,6 +1465,13 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
     if (display->defaultFeedback.wlDmaBufFeedback) {
         zwp_linux_dmabuf_feedback_v1_destroy(display->defaultFeedback.wlDmaBufFeedback);
         display->defaultFeedback.wlDmaBufFeedback = NULL;
+
+        /*
+         * The tranches parsed out of the format table are self-contained
+         * copies, and no further tranche events can arrive once the proxy is
+         * gone, so the mapping is no longer needed.
+         */
+        wlEglFeedbackUnmapFormatTable(&display->defaultFeedback);
     }
 
     if (wlRegistry) {

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -1441,6 +1441,21 @@ EGLBoolean wlEglInitializeHook(EGLDisplay dpy, EGLint *major, EGLint *minor)
     /* We haven't created any surfaces yet, so no need to reallocate. */
     display->defaultFeedback.unprocessedFeedback = false;
 
+    /*
+     * The initial feedback burst was dispatched by the roundtrip above and
+     * its parsed data (format table, tranches) lives in defaultFeedback, not
+     * in the proxy. wlEventQueue is never dispatched again after init, so a
+     * live proxy would only accumulate undispatched resend events, each
+     * holding an open format-table fd (compositors such as mutter < 50
+     * resend feedback on every scanout-candidacy change), until the process
+     * hits RLIMIT_NOFILE. Destroy the proxy now; per-surface feedback keeps
+     * handling dynamic changes on queues that are dispatched at swap time.
+     */
+    if (display->defaultFeedback.wlDmaBufFeedback) {
+        zwp_linux_dmabuf_feedback_v1_destroy(display->defaultFeedback.wlDmaBufFeedback);
+        display->defaultFeedback.wlDmaBufFeedback = NULL;
+    }
+
     if (major != NULL) {
         *major = display->devDpy->major;
     }

--- a/src/wayland-egldisplay.c
+++ b/src/wayland-egldisplay.c
@@ -173,6 +173,7 @@ wlEglDestroyFeedback(WlEglDmaBufFeedback *feedback)
 
     if (feedback->wlDmaBufFeedback) {
         zwp_linux_dmabuf_feedback_v1_destroy(feedback->wlDmaBufFeedback);
+        feedback->wlDmaBufFeedback = NULL;
     }
 }
 


### PR DESCRIPTION
## Problem

Long-lived EGL clients leak one file descriptor per `zwp_linux_dmabuf_feedback_v1::format_table` event that the compositor resends, until the process hits `RLIMIT_NOFILE`. At that point the kernel silently drops the next `SCM_RIGHTS` fd (see `unix(7)`), libwayland fails demarshalling with:

```
file descriptor expected, object (N), message format_table(hu)
[glfw error 65544]: Wayland: fatal display error: Invalid argument
```

and the client exits. Observed in the wild with kitty 0.47.4 on GNOME 46 (mutter 46.2) with NVIDIA 580.159.03: the client process accumulated hundreds of open 4032-byte `/memfd:mutter-shared` fds (each exactly the 252-entry format+modifier table) at ~24–38 fds/min under frequent feedback resends, and crashed roughly every 40 minutes against the default 1024 soft limit.

This is the client-side half of a known cross-stack issue:

- https://gitlab.freedesktop.org/wayland/wayland/-/issues/594 (closed as not-a-libwayland-bug: clients must not exhaust fds; connection death is unrecoverable by design)
- https://gitlab.gnome.org/GNOME/mutter/-/issues/4573, fixed compositor-side by https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4838 — but only in mutter >= 50; mutter 46/48/49 deployments (e.g. Ubuntu 24.04 LTS) resend the format table with a fresh fd on every scanout-candidacy change and remain in the field for years
- https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/4088 (same compositor-side issue in wlroots, fixed May 2026)

## Root causes in egl-wayland

1. **The default feedback proxy outlives the last dispatch of its queue.** The default dmabuf feedback is bound on the display's internal `wlEventQueue`, which is never dispatched again after `eglInitialize` completes. Every feedback resend therefore parks a closure holding an open format-table fd on that queue forever. The parsed data (format table, tranches) lives in `defaultFeedback` and remains valid; resent updates were never processed anyway. This PR destroys the proxy once the initial burst has been handled — per-surface feedback still tracks dynamic changes on surface queues, which are dispatched at swap time. (If maintainers prefer keeping the proxy alive and instead dispatching the queue periodically, happy to rework.)

2. **`dmabuf_feedback_check_format_table()` ignores the fd without closing it** — one leaked fd per EGL display initialization since the probe was introduced in 1.1.14.

3. **`dmabuf_feedback_format_table()` never unmaps the previous table on a resend**, leaking the old mapping each time a resend is actually dispatched (per-surface feedback path).

## Testing

- Built on Ubuntu 24.04 (driver 580.159.03, mutter 46.2, wayland 1.22) and run under kitty: rendering, resize, and fullscreen toggling behave normally.
- `WAYLAND_DEBUG=1` confirms the default feedback proxy is now destroyed right after the init roundtrip (`zwp_linux_dmabuf_feedback_v1.destroy()` immediately follows the initial `done()`), so compositors stop resending to it entirely.
- Leak measurable before/after via `ls -l /proc/<pid>/fd | grep -c memfd` under a compositor that resends feedback.
