### PR TITLE
Remove the unused queue parameter from wlEglSendDamageEvent.

### DIFF
--- a/include/wayland-eglsurface-internal.h
+++ b/include/wayland-eglsurface-internal.h
@@ -206,7 +206,6 @@ EGLBoolean
 wlEglSurfaceCheckReleasePoints(WlEglDisplay *display, WlEglSurface *surface);
 
 EGLBoolean wlEglSendDamageEvent(WlEglSurface *surface,
-                                struct wl_event_queue *queue,
                                 EGLint *rects,
                                 EGLint n_rects);
 

--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -243,7 +243,6 @@ send_explicit_sync_points (WlEglDisplay *display, WlEglSurface *surface,
 
 EGLBoolean
 wlEglSendDamageEvent(WlEglSurface *surface,
-                     struct wl_event_queue *queue,
                      EGLint *rects,
                      EGLint n_rects)
 {
@@ -321,9 +320,7 @@ damage_thread(void *args)
     WlEglSurface          *surface = (WlEglSurface*)args;
     WlEglDisplay          *display = surface->wlEglDpy;
     WlEglPlatformData     *data    = display->data;
-    struct wl_event_queue *queue   = wl_display_create_queue(
-                                        display->nativeDpy);
-    int                    ok      = (queue != NULL);
+    int                    ok      = 1;
     EGLint                 state;
 
     while (ok) {
@@ -377,7 +374,7 @@ damage_thread(void *args)
 
                 wlEglCreateFrameSync(surface);
 
-                ok = wlEglSendDamageEvent(surface, queue, NULL, 0);
+                ok = wlEglSendDamageEvent(surface, NULL, 0);
                 surface->ctx.framesProcessed++;
 
                 pthread_cond_signal(&surface->condFrameSync);
@@ -397,7 +394,6 @@ damage_thread(void *args)
         }
     }
 
-    wl_event_queue_destroy(queue);
     data->egl.releaseThread();
 
     return NULL;

--- a/src/wayland-eglswap.c
+++ b/src/wayland-eglswap.c
@@ -147,7 +147,7 @@ EGLBoolean wlEglSwapBuffersWithDamageHook(EGLDisplay eglDisplay, EGLSurface eglS
             surface->ctx.framesProduced++;
         } else {
             wlEglCreateFrameSync(surface);
-            res = wlEglSendDamageEvent(surface, surface->wlEventQueue, rects, n_rects);
+            res = wlEglSendDamageEvent(surface, rects, n_rects);
             wlEglSurfaceCheckReleasePoints(display, surface);
         }
     }
@@ -434,7 +434,7 @@ EGLBoolean wlEglPostPresentExport2(WlEglSurface *surface,
         surface->ctx.framesProduced++;
     } else {
         wlEglCreateFrameSync(surface);
-        res = wlEglSendDamageEvent(surface, surface->wlEventQueue, NULL, 0);
+        res = wlEglSendDamageEvent(surface, NULL, 0);
     }
 
     // Release wlEglSurface lock.


### PR DESCRIPTION
This removes the now-unused queue parameter in `wlEglSendDamageEvent`, and the local wl_event_queue that we allocate but no longer use in `damage_thread`.
