### PR TITLE
egl-wayland: Initialize streamImages in wlEglCreateSurfaceExport

### DIFF
--- a/src/wayland-eglsurface.c
+++ b/src/wayland-eglsurface.c
@@ -2186,6 +2186,11 @@ WlEglSurface *wlEglCreateSurfaceExport(EGLDisplay dpy,
     }
 
     surface->refCount = 1;
+    wl_list_init(&surface->ctx.streamImages);
+
+    if (!wlEglInitializeMutex(&surface->ctx.streamImagesMutex)) {
+        goto fail;
+    }
 
     if (!wlEglInitializeMutex(&surface->mutexLock)) {
         goto fail;


### PR DESCRIPTION
### Environment

- egl-wayland 1.1.21 (the code is unchanged in current master, 5f743e6)
- NVIDIA 535.309.01, i.e. a driver that still ships `libnvidia-vulkan-producer.so` (545.23.06 and later do not use this path)
- GNOME / Mutter Wayland session without `wl_eglstream_controller`, so surfaces take the local stream + linux-dmabuf ("image stream") path
- Client: Telegram Desktop using Qt 6's Vulkan QRhi backend; any `VK_KHR_wayland_surface` swapchain should behave the same

### Symptom

The very first `vkQueuePresentKHR` of a swapchain segfaults:

```
#0  wl_list_insert () at /usr/lib64/libwayland-server.so.0
#1  add_surface_image (display=<optimized out>, surface=<optimized out>) at ../egl-wayland-1.1.21/src/wayland-eglsurface.c:1567
#2  wlEglHandleImageStreamEvents (surface=0x555556d57000) at ../egl-wayland-1.1.21/src/wayland-eglsurface.c:1620
#3  wlEglSendDamageEvent (surface=surface@entry=0x555556d57000, queue=0x55555f6c5360, rects=rects@entry=0x0, n_rects=n_rects@entry=0) at ../egl-wayland-1.1.21/src/wayland-eglsurface.c:263
#4  wlEglPostPresentExport2 (surface=0x555556d57000, presentId=0, presentInfo=0x0) at ../egl-wayland-1.1.21/src/wayland-eglswap.c:437
#5  ProducerPresentFrame () at /usr/lib64/libnvidia-vulkan-producer.so
#6  ?? () at /usr/lib64/libnvidia-glcore.so.535.309.01
#7  ?? () at /usr/lib64/libnvidia-glcore.so.535.309.01
#8  ?? () at /usr/lib64/libGLX_nvidia.so.0
#9  QRhiVulkan::endFrame(QRhiSwapChain*, QFlags<QRhi::EndFrameFlag>) () at /usr/lib64/libQt6Gui.so.6
```

(`wl_list_insert` resolving to libwayland-server's copy is just symbol interposition, the function is identical in both libraries.)

### Cause

`wlEglCreateSurfaceExport()`, the entry point used by the Vulkan producer, `calloc`s the surface and calls `create_surface_context()`, but never calls `wl_list_init(&surface->ctx.streamImages)` and never initializes `ctx.streamImagesMutex`. Both are set up only in `wlEglInitializeSurfaceCommon()`, which the EGL window and pbuffer hooks use.

With a zeroed list head the first `EGL_STREAM_IMAGE_ADD_NV` event makes `add_surface_image()` run `wl_list_insert(&surface->ctx.streamImages, &image->link)` with `list->next == NULL`, which dereferences NULL. This is the same class of bug as #127, fixed for pbuffer surfaces in #131; the export path was not covered. The list is unused on the `wl_eglstream_controller` path (see the comment in `wlEglDestroySurface`), which is why it only shows up on compositors that dropped EGLStream support.

Same class of bug as #127, which #131 fixed for pbuffer surfaces; the export path used by the Vulkan producer was not covered.
